### PR TITLE
Add new amplify_video_thumb link format to isMobileVideo

### DIFF
--- a/twitter-click-and-save.user.js
+++ b/twitter-click-and-save.user.js
@@ -537,7 +537,7 @@ function hoistFeatures() {
                     continue;
                 }
 
-                const isMobileVideo = img.src.includes("ext_tw_video_thumb")  || img.closest(`a[aria-label="Embedded video"]`) || img.alt === "Animated Text GIF" || img.alt === "Embedded video"
+                const isMobileVideo = img.src.includes("ext_tw_video_thumb") || img.src.includes("amplify_video_thumb") || img.closest(`a[aria-label="Embedded video"]`) || img.alt === "Animated Text GIF" || img.alt === "Embedded video"
                                    || img.src.includes("tweet_video_thumb") /* GIF thumb */;
                 if (isMobileVideo) {
                     await Features.mobileVideoHandler(img, isThumb);


### PR DESCRIPTION
Closes https://github.com/AlttiRi/twitter-click-and-save/issues/45

Adds new video link format that by missing was making some videos download thumbnail instead of source in media tab view.